### PR TITLE
fix typo in documentation

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -12,6 +12,7 @@ name: Upload Python Package
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/docs/asdf.rst
+++ b/docs/asdf.rst
@@ -1,7 +1,7 @@
 ASDF file support in solid-waffle
 #################################
 
-Most Roman data are being distributed in ASDF format. While solid-waffle is capable of reading these directly, it has some scripts that access large numbers of parts of data files, and currently the FITS readers are much faster for this. Therefore, we expect most users will want to convert the data to FITS format (generally format "6").
+Most Roman data are being distributed in ASDF format. While solid-waffle is capable of reading these directly, it has some scripts that access large numbers of parts of data files, and currently the FITS readers are much faster for this. Therefore, we expect most users will want to convert the data to FITS format (the scripts below convert to `format=1` in solid-waffle convention).
 
 To do so, we provide the ``asdf_to_fits`` utility. This can be used as follows:
 


### PR DESCRIPTION
The format written by these scripts is "1", not "6".